### PR TITLE
Fixes segfault that happens when installing via `make install`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,11 +2,14 @@ AUTOMAKE_OPTIONS = foreign
 
 ACLOCAL_AMFLAGS = -I m4
 
+cmusvisdatadir = $(datadir)/cmusvis
+
 bin_PROGRAMS = cmusvis
+cmusvisdata_DATA = new_config
 cmusvis_SOURCES = cmusvis.c
 cmusvis_LDFLAGS = -L/usr/local/lib -Wl,-rpath /usr/local/lib
 cmusvis_CPPFLAGS = -DPACKAGE=\"$(PACKAGE)\" -DVERSION=\"$(VERSION)\" \
-           -D_POSIX_SOURCE -D _POSIX_C_SOURCE=200809L
+           -D_POSIX_SOURCE -D _POSIX_C_SOURCE=200809L -DDATADIR='"$(cmusvisdatadir)"'
 cmusvis_CFLAGS = -std=c99 -Wall -Wextra -Wno-unused-result -Wno-maybe-uninitialized 
 
 

--- a/cmusvis.c
+++ b/cmusvis.c
@@ -127,7 +127,7 @@ FILE *fp;
 	}
 
 
-	FILE* fp2 = fopen("new_config", "r+");
+	FILE* fp2 = fopen(DATADIR "/new_config", "r");
 
 	char curChar;
 	//advance a line


### PR DESCRIPTION
Great program! Noticed a bug when installing this via `make install` though. 

The file `new_config` is not installed in the user's system when installing via `make install`. This patch makes it
so `/usr/local/share/cmusvis` is created on `make install` and contains the needed file.